### PR TITLE
Let the OS find a random port for "auto"

### DIFF
--- a/service_factory/providers/basehttp.py
+++ b/service_factory/providers/basehttp.py
@@ -69,19 +69,13 @@ class HTTPServiceProvider(HTTPServer):
         if self.port != 'auto':
             self.do_bind()
         else:
-            self.port = 9000
-            while True:
-                try:
-                    self.do_bind()
-                except (OSError, socket.error):
-                    self.port += 1
-                else:
-                    break
+            self.port = 0
+            self.do_bind()
+            self.port = self.server_port
             self.report()
 
     def do_bind(self):
         """Perform HTTP server binding and activation."""
-
         HTTPServer.__init__(self, (self.host, self.port), HTTPRequestHandler)
 
     def report(self):


### PR DESCRIPTION
The operating system will automatically pick a free random port for us if we try and bind to port "0".  Essentially this commits makes "auto" an alias to "0", and technically the whole factory class could be reduced to a simple "**init**" which passes "0 if port == 'auto' else port" to the base class parameter for port.

**Disclaimer:** I didn't try it but I'm confident that it works—unless HTTPServer does something stupid that is.  Binding to port 0 is the [official documented way to bind to a free port](http://stackoverflow.com/a/1077305/355252)—at least on Unix.  I don't know about Windows but I can't imagine that winsock wouldn't support this behaviour.

See https://github.com/proofit404/anaconda-mode/issues/198 for background.  
